### PR TITLE
Load missing library

### DIFF
--- a/dom.el
+++ b/dom.el
@@ -58,7 +58,8 @@
 
 ;;; Code:
 (eval-when-compile
-  (require 'cl-lib))
+  (require 'cl-lib)
+  (require 'cl))
 (require 'xml)
 
 ;;; Exception DOMException


### PR DESCRIPTION
'defsetf' is defined at cl.el.
